### PR TITLE
Revert "Documentation update" to merge onto develop instead of general-structure

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -6,9 +6,9 @@ An open approach to resilience
 
 ## First steps
 
-1. Read the [Docs](./README.md) to understand the project.
-2. Read the [Code of Conduct](./docs/CODE_OF_CONDUCT.md) to understand the rules.
-3. Choose the module you want to contribute to from the [Modules](./docs/MODULES.md) list.
+1. Read the [Docs](./docs/README.md) to understand the project.
+2. Read the [Code of Conduct](./CODE_OF_CONDUCT.md) to understand the rules.
+3. Choose the module you want to contribute to from the [Modules](./docs/modules.md) list.
 4. Create your patch or feature and mail it to the module maintainer.
 
 ## What is a module

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Fast and reliable multiplatform kernel
 
 ## Contributing
 
-See CONTRIBUTE.md
+See CONTRIBUTING.md
 


### PR DESCRIPTION
Reverts omen-osdev/omen#24