### PR TITLE
Feature/virtual memory manager

### DIFF
--- a/src/include/omen/managers/mem/vmm.h
+++ b/src/include/omen/managers/mem/vmm.h
@@ -5,9 +5,15 @@
 #include <omen/src/include/omen/managers/mem/pmm.h>
 
 /**
- * Chronological order of table access to convert virtual address to physical address
+ * Chronological order of table access to convert virtual address to physical address for 4kB page size
  * PML4 -> PDPT -> PD -> PT -> Physical base address
  */
+
+// defines number of entry in a particular table
+#define PML4_LEN 512
+#define PDPT_LEN 512
+#define PD_LEN   512
+#define PT_LEN   512
 
 #define SET_ATTRIBUTE(entry, attr) (entry |= attr)
 #define CLEAR_ATTRIBUTE(entry, attr) (entry &= ~attr)
@@ -56,3 +62,15 @@ typedef struct {
     PTE_ACCESSED           = 0x20,                         // 5  bit position
     PTE_XD                 = 0x8000000000000000,           // 63 bit position
 } PageTableEntry_Flag;
+
+// A PML4 table comprises 512 64-bit entries (PML4Es)
+pml4_entry PageMapLevel4[PML4_LEN];
+
+// A page-directory-pointer table comprises 512 64-bit entries (PDPTEs)
+pdpt_entry PageDirectoryPointerTable[PDPT_LEN];
+
+// A page directory comprises 512 64-bit entries (PDEs)
+pd_entry   PageDirectory[PD_LEN];
+
+// A page table comprises 512 64-bit entries (PTEs).
+pt_entry   PageTable[PT_LEN];

--- a/src/include/omen/managers/mem/vmm.h
+++ b/src/include/omen/managers/mem/vmm.h
@@ -1,0 +1,58 @@
+/** 
+ * This header contains declarations for virtual memory manager
+ **/
+#include <omen/src/include/omen/libraries/std/stdint.h>
+#include <omen/src/include/omen/managers/mem/pmm.h>
+
+/**
+ * Chronological order of table access to convert virtual address to physical address
+ * PML4 -> PDPT -> PD -> PT -> Physical base address
+ */
+
+#define SET_ATTRIBUTE(entry, attr) (entry |= attr)
+#define CLEAR_ATTRIBUTE(entry, attr) (entry &= ~attr)
+
+typedef uint64_t pml4_entry;
+typedef uint64_t pdpt_entry;
+typedef uint64_t pd_entry;
+typedef uint64_t pt_entry;
+
+typedef struct {
+    PML4E_PRESENT           = 0x01,                         // 0  bit position
+    PML4E_READ_WRITE        = 0x02,                         // 1  bit position
+    PML4E_USER_SUPERVISOR   = 0x04,                         // 2  bit position
+    PML4E_WRITE_THROUGH     = 0x08,                         // 3  bit position
+    PML4E_CACHE_DISABLE     = 0x10,                         // 4  bit position
+    PML4E_ACCESSED          = 0x20,                         // 5  bit position
+    PML4E_XD                = 0x8000000000000000,           // 63 bit position
+} PageMapLevel4Entry_Flag;
+
+typedef struct {
+    PDPTE_PRESENT           = 0x01,                         // 0  bit position
+    PDPTE_READ_WRITE        = 0x02,                         // 1  bit position
+    PDPTE_USER_SUPERVISOR   = 0x04,                         // 2  bit position
+    PDPTE_WRITE_THROUGH     = 0x08,                         // 3  bit position
+    PDPTE_CACHE_DISABLE     = 0x10,                         // 4  bit position
+    PDPTE_ACCESSED          = 0x20,                         // 5  bit position
+    PDPTE_XD                = 0x8000000000000000,           // 63 bit position
+} PageDirectoryPointerTableEntry_Flag;
+
+typedef struct {
+    PDE_PRESENT            = 0x01,                         // 0  bit position
+    PDE_READ_WRITE         = 0x02,                         // 1  bit position
+    PDE_USER_SUPERVISOR    = 0x04,                         // 2  bit position
+    PDE_WRITE_THROUGH      = 0x08,                         // 3  bit position
+    PDE_CACHE_DISABLE      = 0x10,                         // 4  bit position
+    PDE_ACCESSED           = 0x20,                         // 5  bit position
+    PDE_XD                 = 0x8000000000000000,           // 63 bit position
+} PageDirectoryEntry_Flag;
+
+typedef struct {
+    PTE_PRESENT            = 0x01,                         // 0  bit position
+    PTE_READ_WRITE         = 0x02,                         // 1  bit position
+    PTE_USER_SUPERVISOR    = 0x04,                         // 2  bit position
+    PTE_WRITE_THROUGH      = 0x08,                         // 3  bit position
+    PTE_CACHE_DISABLE      = 0x10,                         // 4  bit position
+    PTE_ACCESSED           = 0x20,                         // 5  bit position
+    PTE_XD                 = 0x8000000000000000,           // 63 bit position
+} PageTableEntry_Flag;

--- a/src/include/omen/managers/mem/vmm/paging_structs.h
+++ b/src/include/omen/managers/mem/vmm/paging_structs.h
@@ -1,12 +1,17 @@
 /** 
- * This header contains declarations for virtual memory manager
+ * This header contains the structures for all the page table entries
+ * required to convert virtual address to physical address
+ * for 4 kB page size
  **/
 #include <omen/src/include/omen/libraries/std/stdint.h>
 #include <omen/src/include/omen/managers/mem/pmm.h>
 
 /**
- * Chronological order of table access to convert virtual address to physical address for 4kB page size
+ * Chronological order of table access to convert virtual address to 
+ * physical address for 4kB page size
  * PML4 -> PDPT -> PD -> PT -> Physical base address
+ * refer to Intel® 64 and IA-32 Architectures Software Developer’s Manual
+ * volume 3, chapter 4
  */
 
 // defines number of entry in a particular table


### PR DESCRIPTION
I have defined the basic page-table entries required for converting virtual address to physical address as per the Intel manual for x86 and x86_64. These structures are for 4kB page size translation.